### PR TITLE
Increase service start-up timeout

### DIFF
--- a/cfg/opx-nas-init.service
+++ b/cfg/opx-nas-init.service
@@ -8,7 +8,7 @@ Type=oneshot
 RemainAfterExit=yes
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/python -u /usr/bin/base_nas_default_init.py
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-daemon], [2.2.0+opx2], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-daemon], [2.2.0+opx3], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+opx-nas-daemon (2.2.0+opx3) unstable; urgency=medium
+
+  * Update: Increase service start-up time-out
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 13 Sep 2018  11:36:00 -0800
+
 opx-nas-daemon (2.2.0+opx2) unstable; urgency=medium
 
-  * Bugfix: Modify dn_rules.sh to prevent ARP requests going 
+  * Bugfix: Modify dn_rules.sh to prevent ARP requests going
             into NFLOG filter to solve ping issues
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 31 Aug 2018 14:44:50 -0800


### PR DESCRIPTION
Increase the service start-up timeout to lower the
probability of a service timing out during boot-up.
This change doubles the timeout length.

Signed-off-by: Garrick He <garrick_he@dell.com>