### PR TITLE
fix: change ebtables rule to solve ping issues

### DIFF
--- a/cfg/dn_rules.sh
+++ b/cfg/dn_rules.sh
@@ -49,8 +49,6 @@ ebtables -t nat -A POSTROUTING -d Multicast --mark 0x1 -j DROP
 
 #Accept ARP request on eth0 (untagged/tagged interfaces) and don't copy it to NFLOG
 ebtables -A OUTPUT -p ARP -o eth0+ --arp-op Request -j ACCEPT
-#NFLOG to copy all ARP requests to netlink group 100
-ebtables -A OUTPUT -p ARP --arp-op Request --nflog-group 100 -j DROP
 
 # Avoiding the VRRP MAC destined packets flooding in bridge level, redirecting the packets
 # to the next layer (routing) for further lookup.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-daemon], [2.2.0+opx1], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-daemon], [2.2.0+opx2], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+opx-nas-daemon (2.2.0+opx2) unstable; urgency=medium
+
+  * Bugfix: Modify dn_rules.sh to prevent ARP requests going 
+            into NFLOG filter to solve ping issues
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 31 Aug 2018 14:44:50 -0800
+
 opx-nas-daemon (2.2.0+opx1) unstable; urgency=medium
 
   * Bugfix: Service start-up dependencies and timing


### PR DESCRIPTION
Temporary fix - Modify dn_rules.sh to prevent ARP requests going into NFLOG filter to solve ping issues

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>