### PR TITLE
Fix: Service startup sequence

### DIFF
--- a/cfg/opx-nas-init.service
+++ b/cfg/opx-nas-init.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Network abstraction initiation
-After=opx-cps.service
-Requires=opx-cps.service
+After=opx-cps.service opx-nas.service
+Requires=opx-cps.service opx-nas.service
 
 [Service]
 Type=oneshot

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-daemon], [2.2.0+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-daemon], [2.2.0+opx4], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-nas-daemon (2.2.0+opx4) unstable; urgency=medium
+
+  * Update: Service startup sequence
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 14 Sep 2018  11:36:00 -0800
+
 opx-nas-daemon (2.2.0+opx3) unstable; urgency=medium
 
   * Update: Increase service start-up time-out


### PR DESCRIPTION
This fix ensures that opx-nas related services are starting in
the proper dependency order.

Signed-off-by: Garrick He <garrick_he@dell.com>