### PR TITLE
fix: ARP request not working when NFLOG is enabled

### DIFF
--- a/cfg/dn_rules.sh
+++ b/cfg/dn_rules.sh
@@ -64,4 +64,4 @@ ebtables -t nat -A IPV6VRRP -p IPv6 --ip6-protocol ipv6-icmp -j RETURN
 ebtables -t nat -A IPV6VRRP -p IPv6 -j redirect --redirect-target ACCEPT
 
 #NFLOG to copy all ARP requests to netlink group 100
-ebtables -A OUTPUT -p ARP --arp-op Request --nflog-group 100 -j DROP
+ebtables -A OUTPUT -p ARP --arp-op Request --nflog-group 100 --nflog-range 28 -j DROP

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-daemon], [2.2.0+opx5], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-daemon], [2.2.0+opx6], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+opx-nas-daemon (2.2.0+opx6) unstable; urgency=medium
+
+  * Bugfix: Explicit state the number of bytes nfnetlink_logger instance
+            should copy to user-space application
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 04 Dec 2018  11:36:00 -0800
+
 opx-nas-daemon (2.2.0+opx5) unstable; urgency=medium
 
   * Update: Modify dn_rules.sh to re-enable NFLOG for ARP request


### PR DESCRIPTION
* Bugfix: Explicit state the number of bytes nfnetlink_logger instance
          should copy to user-space application

Signed-off-by: Garrick He <garrick_he@dell.com>